### PR TITLE
Splashscreen working and image scaled appropriately

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,6 @@ class MyApp extends StatelessWidget {
         backgroundColor: Color(0xFFE1DFD8),
         brightness: Brightness.dark,
       ),
-      initialRoute: 'Home',
       home: AnimatedSplashScreen(
         splash: Image.asset(
           'assets/images/Home/Logo.png',
@@ -28,6 +27,7 @@ class MyApp extends StatelessWidget {
         nextScreen: HomePage(),
         splashTransition: SplashTransition.rotationTransition,
         backgroundColor: Color(0xFFE1DFD8),
+        splashIconSize: 250,
       ),
       routes: {
         'Home': (context) => HomePage(),


### PR DESCRIPTION
Easy one to test. Just run the app and if you see the splashscreen with a much bigger splash icon then job is done. If it doesn't show up the first time just restart the connection and it should appear (this is just emulator jankyness)